### PR TITLE
`similarterm`, `issym` and `istree` can be called only on objects, not on types

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TermInterface"
 uuid = "8ea1fca8-c5ef-4a55-8b96-4e9afe9c9a3c"
 authors = ["Shashi Gowda <gowda@mit.edu>", "Alessandro Cheli <sudo-woodo3@protonmail.com>"]
-version = "0.2.3"
+version = "0.3.0"
 
 [compat]
 julia = "1"

--- a/src/TermInterface.jl
+++ b/src/TermInterface.jl
@@ -6,8 +6,7 @@ module TermInterface
 Returns `true` if `x` is a term. If true, `operation`, `arguments`
 must also be defined for `x` appropriately.
 """
-istree(x) = istree(typeof(x))
-istree(x::Type{T}) where {T} = false
+istree(x) = false
 export istree
 
 """
@@ -29,8 +28,7 @@ export symtype
 Returns `true` if `x` is a symbol. If true, `nameof` must be defined
 on `x` and must return a Symbol.
 """
-issym(x) = issym(typeof(x))
-issym(x::Type{T}) where {T} = false
+issym(x) = false
 export issym
 
 """

--- a/src/TermInterface.jl
+++ b/src/TermInterface.jl
@@ -117,16 +117,9 @@ and `metadata` as the metadata. By default this will execute `head(args...)`.
 when manipulating `Expr`s.
 """
 function similarterm(x, head, args, symtype = nothing; metadata = nothing, exprhead = nothing)
-  if exprhead === nothing
-    similarterm(typeof(x), head, args, symtype; metadata = metadata)
-  else
-    similarterm(typeof(x), head, args, symtype; metadata = metadata, exprhead = exprhead)
-  end
+  !istree(x) ? head : head(args...)
 end
 
-function similarterm(x::Type{T}, head, args, symtype = nothing; metadata = nothing, exprhead = :call) where {T}
-  !istree(T) ? head : head(args...)
-end
 export similarterm
 
 include("utils.jl")

--- a/src/expr.jl
+++ b/src/expr.jl
@@ -16,10 +16,6 @@ expr_arguments(e::Expr, ::Union{Val{:call},Val{:macrocall}}) = e.args[2:end]
 expr_arguments(e::Expr, _) = e.args
 
 
-function similarterm(x::Type{Expr}, head, args, symtype = nothing; metadata = nothing, exprhead = :call)
-  expr_similarterm(head, args, Val{exprhead}())
-end
-
 function similarterm(x::Expr, head, args, symtype = nothing; metadata = nothing, exprhead = exprhead(x))
   expr_similarterm(head, args, Val{exprhead}())
 end

--- a/src/expr.jl
+++ b/src/expr.jl
@@ -1,7 +1,7 @@
 # This file contains default definitions for TermInterface methods on Julia
 # Builtin Expr type.
 
-istree(x::Type{Expr}) = true
+istree(x::Expr) = true
 exprhead(e::Expr) = e.head
 
 operation(e::Expr) = expr_operation(e, Val{exprhead(e)}())

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,8 +1,8 @@
 using TermInterface
 using Test
 
-@testset "Expr" begin 
-    ex = :(f(a,b))
+@testset "Expr" begin
+    ex = :(f(a, b))
     @test operation(ex) == :f
     @test arguments(ex) == [:a, :b]
     @test exprhead(ex) == :call
@@ -12,7 +12,7 @@ using Test
     @test operation(ex) == getindex
     @test arguments(ex) == [:arr, :i, :j]
     @test exprhead(ex) == :ref
-    @test ex == similarterm(Expr, :ref, [:arr, :i, :j]; exprhead=:ref)
+    @test ex == similarterm(ex, :ref, [:arr, :i, :j]; exprhead = :ref)
     @test ex == similarterm(ex, :ref, [:arr, :i, :j])
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -15,5 +15,3 @@ using Test
     @test ex == similarterm(ex, :ref, [:arr, :i, :j]; exprhead = :ref)
     @test ex == similarterm(ex, :ref, [:arr, :i, :j])
 end
-
-# TODO add SymbolicUtils tests??


### PR DESCRIPTION
Fixes https://github.com/JuliaSymbolics/SymbolicUtils.jl/pull/432/files