### PR TITLE
Compromise Interface Redesign

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TermInterface"
 uuid = "8ea1fca8-c5ef-4a55-8b96-4e9afe9c9a3c"
 authors = ["Shashi Gowda <gowda@mit.edu>", "Alessandro Cheli <sudo-woodo3@protonmail.com>"]
-version = "0.3.3"
+version = "0.4.0"
 
 [compat]
 julia = "1"

--- a/README.md
+++ b/README.md
@@ -9,62 +9,69 @@ You should define the following methods for an expression tree type `T` with sym
 with TermInterface.jl, and therefore with [SymbolicUtils.jl](https://github.com/JuliaSymbolics/SymbolicUtils.jl) 
 and [Metatheory.jl](https://github.com/0x0f0f0f/Metatheory.jl).
 
-#### `istree(x::T)` or `istree(x::Type{T})`
+#### `isexpr(x::T)` 
 
-Check if `x` represents an expression tree. If returns true,
-it will be assumed that `operation(::T)` and `arguments(::T)`
-methods are defined. Definining these three should allow use
-of `SymbolicUtils.simplify` on custom types. Optionally `symtype(x)` can be
-defined to return the expected type of the symbolic expression.
+Returns `true` if `x` is an expression tree (an S-expression). If true, `head`
+and `children` methods must be defined for `x`.
+
+#### `iscall(x::T)`
+
+Returns `true` if `x` is a function call expression. If true, `operation`, `arguments` must also be defined for `x::T`.
 
 
-#### `exprhead(x)`
+#### `head(x)`
 
-If `x` is a term as defined by `istree(x)`, `exprhead(x)` must return a symbol,
-corresponding to the head of the `Expr` most similar to the term `x`.
-If `x` represents a function call, for example, the `exprhead` is `:call`.
-If `x` represents an indexing operation, such as `arr[i]`, then `exprhead` is `:ref`.
-Note that `exprhead` is different from `operation` and both functions should 
-be defined correctly in order to let other packages provide code generation 
-and pattern matching features. 
+Returns the head of the S-expression.
 
-#### `operation(x::T)`
+#### `children(x)`
 
-Returns the head (a function object) performed by an expression
-tree. Called only if `istree(::T)` is true. Part of the API required
-for `simplify` to work. Other required methods are `arguments` and `istree`
+Returns the children (aka tail) of the S-expression.
 
-#### `arguments(x::T)`
 
-Returns the arguments (a `Vector`) for an expression tree.
-Called only if `istree(x)` is `true`. Part of the API required
-for `simplify` to work. Other required methods are `operation` and `istree`
+#### `operation(x)`
 
-In addition, the methods for `Base.hash` and `Base.isequal` should also be implemented by the types for the purposes of substitution and equality matching respectively.
+Returns the function a function call expression is calling. `iscall(x)` must be
+true as a precondition.
 
-#### `similarterm(t::MyType, f, args, symtype=T; metadata=nothing, exprhead=exprhead(t))`
+#### `arguments(x)`
 
-Or `similarterm(t::Type{MyType}, f, args, symtype=T; metadata=nothing, exprhead=:call)`.
+Returns the arguments to the function call in a function call expression.
+`iscall(x)` must be true as a precondition.
 
-Construct a new term with the operation `f` and arguments `args`, the term should be similar to `t` in type. if `t` is a `SymbolicUtils.Term` object a new Term is created with the same symtype as `t`. If not, the result is computed as `f(args...)`. Defining this method for your term type will reduce any performance loss in performing `f(args...)` (esp. the splatting, and redundant type computation). T is the symtype of the output term. You can use `SymbolicUtils.promote_symtype` to infer this type. The `exprhead` keyword argument is useful when creating `Expr`s.
+#### `maketerm(T, head, children, type=nothing, metadata=nothing)`
+
+Constructs an expression. `T` is a constructor type, `head` and `children` are
+the head and tail of the S-expression, `type` is the `type` of the S-expression.
+`metadata` is any metadata attached to this expression.
+
+Note that `maketerm` may not necessarily return an object of type `T`. For example,
+it may return a representation which is more efficient.
+
+This function is used by term-manipulation routines to construct terms generically.
+In these routines, `T` is usually the type of the input expression which is being manipulated.
+For example, when a subexpression is substituted, the outer expression is re-constructed with
+the sub-expression. `T` will be the type of the outer expression.
+
+Packages providing expression types _must_ implement this method for each expression type.
+
+If your types do not support type information or metadata, you still need to accept
+these arguments and may choose to not use them.
 
 ### Optional
 
-#### `unsorted_arguments(x)`
+#### `arity(x)`
 
-If x is a term satisfying `istree(x)` and your term type `T` provides
-an optimized implementation for storing the arguments, this function can 
-be used to retrieve the arguments when the order of arguments does not matter 
-but the speed of the operation does. Defaults to `arguments(x)`.
+When `x` satisfies `iscall`, returns the number of arguments of `x`.
+Implicitly defined if `arguments(x)` is defined.
 
-#### `symtype(x)`
 
-The supposed type of values in the domain of x. Tracing tools can use this type to
-pick the right method to run or analyse code.
+#### `metadata(x)`
 
-This defaults to `typeof(x)` if `x` is numeric, or `Any` otherwise.
-For the types defined in this SymbolicUtils.jl, namely `T<:Symbolic{S}` it is `S`.
+Returns the metadata attached to `x`.
 
+#### `symtype(expr)`
+
+Returns the symbolic type of `expr`. By default this is just `typeof(expr)`.
 Define this for your symbolic types if you want `SymbolicUtils.simplify` to apply rules
 specific to numbers (such as commutativity of multiplication). Or such
 rules that may be implemented in the future.

--- a/src/TermInterface.jl
+++ b/src/TermInterface.jl
@@ -103,7 +103,7 @@ function similarterm(x, head, args, symtype = nothing; metadata = nothing)
   similarterm(typeof(x), head, args, symtype = symtype, metadata = metadata)
 end
 
-function similarterm(x::DataType, head, args, symtype = nothing; metadata = nothing)
+function similarterm(T::DataType, head, args, symtype = nothing; metadata = nothing)
   head(args...)
 end
 

--- a/src/TermInterface.jl
+++ b/src/TermInterface.jl
@@ -13,7 +13,7 @@ export iscall
 
 Alias of `iscall`
 """
-@depricate_binding istree iscall
+Base.@deprecate_binding istree iscall
 
 """
     isexpr(x)
@@ -120,10 +120,18 @@ end
 
 """
 function similarterm(x, op, args, symtype = nothing; metadata = nothing)
+    Base.depwarn("""`similarterm` is deprecated, use `maketerm` instead.
+                    See https://github.com/JuliaSymbolics/TermInterface.jl for details.
+                    The present call can be replaced by
+                    `maketerm(typeof(x), $(callhead(x)), [op, args...], symtype, metadata)`""")
+
     maketerm(typeof(x), callhead(x), [op, args...], symtype, metadata)
 end
+
 # Old fallback
 function similarterm(T::Type, op, args, symtype = nothing; metadata = nothing)
+    Base.depwarn("`similarterm` is deprecated, use `maketerm` instead." *
+                 "See https://github.com/JuliaSymbolics/TermInterface.jl for details.")
     op(args...)
 end
 
@@ -149,7 +157,11 @@ Note that `maketerm` may not necessarily return an object of type `T`. For examp
 it may return a representation which is more efficient.
 
 This function is used by term-manipulation routines to construct terms generically.
-Packages providing expression types must implement this method for each expression type.
+In these routines, `T` is usually the type of the input expression which is being manipulated.
+For example, when a subexpression is substituted, the outer expression is re-constructed with
+the sub-expression. `T` will be the type of the outer expression.
+
+Packages providing expression types _must_ implement this method for each expression type.
 
 If your types do not support type information or metadata, you still need to accept
 these arguments and may choose to not use them.

--- a/src/TermInterface.jl
+++ b/src/TermInterface.jl
@@ -1,18 +1,31 @@
 module TermInterface
 
 """
-  istree(x)
-
-Returns `true` if `x` is a term. If true, `operation`, `arguments`
-must also be defined for `x` appropriately.
+    iscall(x)
+Returns `true` if `x` is a function call expression. If true, `operation`, `arguments`
+must also be defined for `x`.
 """
-istree(x) = false
-export istree
+iscall(x) = false
+export iscall
 
 """
-  symtype(x)
+   istree(x)
 
-Returns the symbolic type of `x`. By default this is just `typeof(x)`.
+Alias of `iscall`
+"""
+@depricate_binding istree iscall
+
+"""
+    isexpr(x)
+Returns `true` if `x` is an expression tree (an S-expression). If true, `head` and `children` methods must be defined for `x`.
+"""
+isexpr(x) = false
+export isexpr
+
+"""
+    symtype(expr)
+
+Returns the symbolic type of `expr`. By default this is just `typeof(expr)`.
 Define this for your symbolic types if you want `SymbolicUtils.simplify` to apply rules
 specific to numbers (such as commutativity of multiplication). Or such
 rules that may be implemented in the future.
@@ -23,7 +36,7 @@ end
 export symtype
 
 """
-  issym(x)
+    issym(x)
 
 Returns `true` if `x` is a symbol. If true, `nameof` must be defined
 on `x` and must return a Symbol.
@@ -32,27 +45,40 @@ issym(x) = false
 export issym
 
 """
+    head(x)
+Returns the head of the S-expression.
+"""
+function head end
+
+"""
+    children(x)
+Returns the children (aka tail) of the S-expression.
+"""
+function children end
+
+"""
   operation(x)
 
-If `x` is a term as defined by `istree(x)`, `operation(x)` returns the
-head of the term if `x` represents a function call, for example, the head
-is the function being called.
+Returns the function a function call expression is calling.
+`iscall(x)` must be true as a precondition.
 """
-function operation end
+operation(x) = iscall(x) ? first(children(x)) : error("operation called on a non-function call expression")
 export operation
 
 """
   arguments(x)
 
-Get the arguments of `x`, must be defined if `istree(x)` is `true`.
+Returns the arguments to the function call in a function call expression.
+`iscall(x)` must be true as a precondition.
 """
 function arguments end
+arguments(x) = iscall(x) ? Iterators.drop(children(x), 1) : error("arguments called on a non-function call expression")
 export arguments
 
 """
   unsorted_arguments(x::T)
 
-If x is a term satisfying `istree(x)` and your term type `T` orovides
+If x is a expression satisfying `iscall(x)` and your expression type `T` provides
 and optimized implementation for storing the arguments, this function can 
 be used to retrieve the arguments when the order of arguments does not matter 
 but the speed of the operation does.
@@ -64,8 +90,8 @@ export unsorted_arguments
 """
   arity(x)
 
-Returns the number of arguments of `x`. Implicitly defined 
-if `arguments(x)` is defined.
+When `x` satisfies `iscall`, returns the number of arguments of `x`.
+Implicitly defined if `arguments(x)` is defined.
 """
 arity(x) = length(arguments(x))
 export arity
@@ -74,40 +100,64 @@ export arity
 """
   metadata(x)
 
-Return the metadata attached to `x`.
+Returns the metadata attached to `x`.
 """
 metadata(x) = nothing
 export metadata
 
 
 """
-  metadata(x, md)
+  metadata(expr, md)
 
-Returns a new term which has the structure of `x` but also has
-the metadata `md` attached to it.
+Returns a `expr` with metadata `md` attached to it.
 """
 function metadata(x, data)
-  error("Setting metadata on $x is not possible")
+  error("Setting metadata on $x is not implemented")
 end
 
 """
-  similarterm(x, head, args, symtype=nothing; metadata=nothing)
+    similarterm(x, op, args, symtype=nothing; metadata=nothing)
 
-Returns a term that is in the same closure of types as `typeof(x)`,
-with `head` as the head and `args` as the arguments, `type` as the symtype
-and `metadata` as the metadata. By default this will execute `head(args...)`.
-`x` parameter can also be a `Type`. Implementers should define similarterm on the
-type of `x` and not on `x` itself.
 """
-function similarterm(x, head, args, symtype = nothing; metadata = nothing)
-  similarterm(typeof(x), head, args, symtype = symtype, metadata = metadata)
+function similarterm(x, op, args, symtype = nothing; metadata = nothing)
+    maketerm(typeof(x), callhead(x), [op, args...], symtype, metadata)
 end
-
-function similarterm(T::Type, head, args, symtype = nothing; metadata = nothing)
-  head(args...)
+# Old fallback
+function similarterm(T::Type, op, args, symtype = nothing; metadata = nothing)
+    op(args...)
 end
 
 export similarterm
+
+
+"""
+    callhead(x)
+Used in this deprecation cycle of `similarterm` to find the `head` argument to
+`makterm`. Do not implement this, or use `similarterm` if you're using this package.
+"""
+callhead(x) = typeof(x)
+callhead(x::Expr) = Expr
+
+"""
+    maketerm(T, head, children, type, metadata)
+
+Constructs an expression. `T` is a constructor type, `head` and `children` are
+the head and tail of the S-expression, `type` is the `type` of the S-expression.
+`metadata` is any metadata attached to this expression.
+
+Note that `maketerm` may not necessarily return an object of type `T`. For example,
+it may return a representation which is more efficient.
+
+This function is used by term-manipulation routines to construct terms generically.
+Packages providing expression types must implement this method for each expression type.
+
+If your types do not support type information or metadata, you still need to accept
+these arguments and may choose to not use them.
+"""
+
+function maketerm(T::Type, head, children, type, metadata)
+    error("maketerm for $T is not impmlemented")
+end
 
 include("utils.jl")
 

--- a/src/TermInterface.jl
+++ b/src/TermInterface.jl
@@ -50,12 +50,14 @@ export issym
 Returns the head of the S-expression.
 """
 function head end
+export head
 
 """
     children(x)
 Returns the children (aka tail) of the S-expression.
 """
 function children end
+export children
 
 """
   operation(x)
@@ -119,20 +121,20 @@ end
     similarterm(x, op, args, symtype=nothing; metadata=nothing)
 
 """
-function similarterm(x, op, args, symtype = nothing; metadata = nothing)
-    Base.depwarn("""`similarterm` is deprecated, use `maketerm` instead.
-                    See https://github.com/JuliaSymbolics/TermInterface.jl for details.
-                    The present call can be replaced by
-                    `maketerm(typeof(x), $(callhead(x)), [op, args...], symtype, metadata)`""", :similarterm)
+function similarterm(x, op, args, symtype=nothing; metadata=nothing)
+  Base.depwarn("""`similarterm` is deprecated, use `maketerm` instead.
+                  See https://github.com/JuliaSymbolics/TermInterface.jl for details.
+                  The present call can be replaced by
+                  `maketerm(typeof(x), $(head(x)), [op, args...], symtype, metadata)`""", :similarterm)
 
-    maketerm(typeof(x), callhead(x), [op, args...], symtype, metadata)
+  maketerm(typeof(x), callhead(x), [op, args...], symtype, metadata)
 end
 
 # Old fallback
-function similarterm(T::Type, op, args, symtype = nothing; metadata = nothing)
-    Base.depwarn("`similarterm` is deprecated, use `maketerm` instead." *
-                 "See https://github.com/JuliaSymbolics/TermInterface.jl for details.", :similarterm)
-    op(args...)
+function similarterm(T::Type, op, args, symtype=nothing; metadata=nothing)
+  Base.depwarn("`similarterm` is deprecated, use `maketerm` instead." *
+               "See https://github.com/JuliaSymbolics/TermInterface.jl for details.", :similarterm)
+  op(args...)
 end
 
 export similarterm
@@ -141,7 +143,7 @@ export similarterm
 """
     callhead(x)
 Used in this deprecation cycle of `similarterm` to find the `head` argument to
-`makterm`. Do not implement this, or use `similarterm` if you're using this package.
+`maketerm`. Do not implement this, or use `similarterm` if you're using this package.
 """
 callhead(x) = typeof(x)
 
@@ -166,9 +168,10 @@ If your types do not support type information or metadata, you still need to acc
 these arguments and may choose to not use them.
 """
 
-function maketerm(T::Type, head, children, type, metadata)
-    error("maketerm for $T is not implemented")
+function maketerm(T::Type, head, children, type=nothing, metadata=nothing)
+  error("maketerm for $T is not implemented")
 end
+export maketerm
 
 include("utils.jl")
 

--- a/src/TermInterface.jl
+++ b/src/TermInterface.jl
@@ -8,14 +8,6 @@ must also be defined for `x`.
 iscall(x) = false
 export iscall
 
-Base.@deprecate_binding istree iscall
-"""
-   istree(x)
-
-Alias of `iscall`
-"""
-istree
-
 """
     isexpr(x)
 Returns `true` if `x` is an expression tree (an S-expression). If true, `head` and `children` methods must be defined for `x`.
@@ -119,7 +111,7 @@ end
 
 
 """
-    maketerm(T, head, children, type, metadata)
+    maketerm(T, head, children, type=nothing, metadata=nothing)
 
 Constructs an expression. `T` is a constructor type, `head` and `children` are
 the head and tail of the S-expression, `type` is the `type` of the S-expression.

--- a/src/TermInterface.jl
+++ b/src/TermInterface.jl
@@ -117,35 +117,6 @@ function metadata(x, data)
   error("Setting metadata on $x is not implemented")
 end
 
-"""
-    similarterm(x, op, args, symtype=nothing; metadata=nothing)
-
-"""
-function similarterm(x, op, args, symtype=nothing; metadata=nothing)
-  Base.depwarn("""`similarterm` is deprecated, use `maketerm` instead.
-                  See https://github.com/JuliaSymbolics/TermInterface.jl for details.
-                  The present call can be replaced by
-                  `maketerm(typeof(x), $(head(x)), [op, args...], symtype, metadata)`""", :similarterm)
-
-  maketerm(typeof(x), callhead(x), [op, args...], symtype, metadata)
-end
-
-# Old fallback
-function similarterm(T::Type, op, args, symtype=nothing; metadata=nothing)
-  Base.depwarn("`similarterm` is deprecated, use `maketerm` instead." *
-               "See https://github.com/JuliaSymbolics/TermInterface.jl for details.", :similarterm)
-  op(args...)
-end
-
-export similarterm
-
-
-"""
-    callhead(x)
-Used in this deprecation cycle of `similarterm` to find the `head` argument to
-`maketerm`. Do not implement this, or use `similarterm` if you're using this package.
-"""
-callhead(x) = typeof(x)
 
 """
     maketerm(T, head, children, type, metadata)

--- a/src/TermInterface.jl
+++ b/src/TermInterface.jl
@@ -124,7 +124,7 @@ function similarterm(x, op, args, symtype = nothing; metadata = nothing)
     Base.depwarn("""`similarterm` is deprecated, use `maketerm` instead.
                     See https://github.com/JuliaSymbolics/TermInterface.jl for details.
                     The present call can be replaced by
-                    `maketerm(typeof(x), $(callhead(x)), [op, args...], symtype, metadata)`""")
+                    `maketerm(typeof(x), $(callhead(x)), [op, args...], symtype, metadata)`""", :similarterm)
 
     maketerm(typeof(x), callhead(x), [op, args...], symtype, metadata)
 end
@@ -132,7 +132,7 @@ end
 # Old fallback
 function similarterm(T::Type, op, args, symtype = nothing; metadata = nothing)
     Base.depwarn("`similarterm` is deprecated, use `maketerm` instead." *
-                 "See https://github.com/JuliaSymbolics/TermInterface.jl for details.")
+                 "See https://github.com/JuliaSymbolics/TermInterface.jl for details.", :similarterm)
     op(args...)
 end
 
@@ -145,7 +145,6 @@ Used in this deprecation cycle of `similarterm` to find the `head` argument to
 `makterm`. Do not implement this, or use `similarterm` if you're using this package.
 """
 callhead(x) = typeof(x)
-callhead(x::Expr) = Expr
 
 """
     maketerm(T, head, children, type, metadata)
@@ -169,7 +168,7 @@ these arguments and may choose to not use them.
 """
 
 function maketerm(T::Type, head, children, type, metadata)
-    error("maketerm for $T is not impmlemented")
+    error("maketerm for $T is not implemented")
 end
 
 include("utils.jl")

--- a/src/TermInterface.jl
+++ b/src/TermInterface.jl
@@ -96,9 +96,14 @@ end
 Returns a term that is in the same closure of types as `typeof(x)`,
 with `head` as the head and `args` as the arguments, `type` as the symtype
 and `metadata` as the metadata. By default this will execute `head(args...)`.
-`x` parameter can also be a `Type`.
+`x` parameter can also be a `Type`. Implementers should define similarterm on the
+type of `x` and not on `x` itself.
 """
 function similarterm(x, head, args, symtype = nothing; metadata = nothing)
+  similarterm(typeof(x), head, args, symtype = symtype, metadata = metadata)
+end
+
+function similarterm(x::DataType, head, args, symtype = nothing; metadata = nothing)
   head(args...)
 end
 

--- a/src/TermInterface.jl
+++ b/src/TermInterface.jl
@@ -103,7 +103,7 @@ function similarterm(x, head, args, symtype = nothing; metadata = nothing)
   similarterm(typeof(x), head, args, symtype = symtype, metadata = metadata)
 end
 
-function similarterm(T::DataType, head, args, symtype = nothing; metadata = nothing)
+function similarterm(T::Type, head, args, symtype = nothing; metadata = nothing)
   head(args...)
 end
 

--- a/src/TermInterface.jl
+++ b/src/TermInterface.jl
@@ -8,12 +8,13 @@ must also be defined for `x`.
 iscall(x) = false
 export iscall
 
+Base.@deprecate_binding istree iscall
 """
    istree(x)
 
 Alias of `iscall`
 """
-Base.@deprecate_binding istree iscall
+istree
 
 """
     isexpr(x)

--- a/src/TermInterface.jl
+++ b/src/TermInterface.jl
@@ -32,21 +32,6 @@ issym(x) = false
 export issym
 
 """
-  exprhead(x)
-
-If `x` is a term as defined by `istree(x)`, `exprhead(x)` must return a symbol,
-corresponding to the head of the `Expr` most similar to the term `x`.
-If `x` represents a function call, for example, the `exprhead` is `:call`.
-If `x` represents an indexing operation, such as `arr[i]`, then `exprhead` is `:ref`.
-Note that `exprhead` is different from `operation` and both functions should 
-be defined correctly in order to let other packages provide code generation 
-and pattern matching features. 
-"""
-function exprhead end
-export exprhead
-
-
-"""
   operation(x)
 
 If `x` is a term as defined by `istree(x)`, `operation(x)` returns the
@@ -63,7 +48,6 @@ Get the arguments of `x`, must be defined if `istree(x)` is `true`.
 """
 function arguments end
 export arguments
-
 
 """
   unsorted_arguments(x::T)
@@ -106,18 +90,16 @@ function metadata(x, data)
   error("Setting metadata on $x is not possible")
 end
 
-
 """
-  similarterm(x, head, args, symtype=nothing; metadata=nothing, exprhead=:call)
+  similarterm(x, head, args, symtype=nothing; metadata=nothing)
 
 Returns a term that is in the same closure of types as `typeof(x)`,
 with `head` as the head and `args` as the arguments, `type` as the symtype
 and `metadata` as the metadata. By default this will execute `head(args...)`.
-`x` parameter can also be a `Type`. The `exprhead` keyword argument is useful 
-when manipulating `Expr`s.
+`x` parameter can also be a `Type`.
 """
-function similarterm(x, head, args, symtype = nothing; metadata = nothing, exprhead = nothing)
-    head(args...)
+function similarterm(x, head, args, symtype = nothing; metadata = nothing)
+  head(args...)
 end
 
 export similarterm

--- a/src/TermInterface.jl
+++ b/src/TermInterface.jl
@@ -63,7 +63,7 @@ function children end
 Returns the function a function call expression is calling.
 `iscall(x)` must be true as a precondition.
 """
-operation(x) = iscall(x) ? first(children(x)) : error("operation called on a non-function call expression")
+function operation end
 export operation
 
 """
@@ -73,7 +73,6 @@ Returns the arguments to the function call in a function call expression.
 `iscall(x)` must be true as a precondition.
 """
 function arguments end
-arguments(x) = iscall(x) ? Iterators.drop(children(x), 1) : error("arguments called on a non-function call expression")
 export arguments
 
 """

--- a/src/expr.jl
+++ b/src/expr.jl
@@ -1,11 +1,13 @@
 # This file contains default definitions for TermInterface methods on Julia
 # Builtin Expr type.
 
-istree(x::Expr) = true
+iscall(x::Expr) = x.head == :call
 
-operation(e::Expr) = e.head
-arguments(e::Expr) = e.args
+head(e::Expr) = e.head
+children(e::Expr) = e.args
 
-function similarterm(x::Expr, head, args, symtype = nothing; metadata = nothing)
-  Expr(head, args...)
+# ^ this will implicitly define operation and arguments
+
+function maketerm(::Type{Expr}, head, args, symtype, metadata)
+    Expr(head, args...)
 end

--- a/src/expr.jl
+++ b/src/expr.jl
@@ -7,7 +7,5 @@ operation(e::Expr) = e.head
 arguments(e::Expr) = e.args
 
 function similarterm(x::Expr, head, args, symtype = nothing; metadata = nothing)
-  res = Expr(head)
-  res.args = args
-  res
+  Expr(head, args...)
 end

--- a/src/expr.jl
+++ b/src/expr.jl
@@ -2,25 +2,12 @@
 # Builtin Expr type.
 
 istree(x::Expr) = true
-exprhead(e::Expr) = e.head
 
-operation(e::Expr) = expr_operation(e, Val{exprhead(e)}())
-arguments(e::Expr) = expr_arguments(e, Val{exprhead(e)}())
+operation(e::Expr) = e.head
+arguments(e::Expr) = e.args
 
-# See https://docs.julialang.org/en/v1/devdocs/ast/
-expr_operation(e::Expr, ::Union{Val{:call},Val{:macrocall}}) = e.args[1]
-expr_operation(e::Expr, ::Union{Val{:ref}}) = getindex
-expr_operation(e::Expr, ::Val{T}) where {T} = T
-
-expr_arguments(e::Expr, ::Union{Val{:call},Val{:macrocall}}) = e.args[2:end]
-expr_arguments(e::Expr, _) = e.args
-
-
-function similarterm(x::Expr, head, args, symtype = nothing; metadata = nothing, exprhead = exprhead(x))
-  expr_similarterm(head, args, Val{exprhead}())
+function similarterm(x::Expr, head, args, symtype = nothing; metadata = nothing)
+  res = Expr(head)
+  res.args = args
+  res
 end
-
-
-expr_similarterm(head, args, ::Val{:call}) = Expr(:call, head, args...)
-expr_similarterm(head, args, ::Val{:macrocall}) = Expr(:macrocall, head, args...) # discard linenumbernodes?
-expr_similarterm(head, args, ::Val{eh}) where {eh} = Expr(eh, args...)

--- a/src/expr.jl
+++ b/src/expr.jl
@@ -6,7 +6,8 @@ iscall(x::Expr) = x.head == :call
 head(e::Expr) = e.head
 children(e::Expr) = e.args
 
-# ^ this will implicitly define operation and arguments
+operation(e::Expr) = e.args[1]
+arguments(e::Expr) = e.args[2:end]
 
 function maketerm(::Type{Expr}, head, args, symtype, metadata)
     Expr(head, args...)

--- a/src/expr.jl
+++ b/src/expr.jl
@@ -3,12 +3,13 @@
 
 iscall(x::Expr) = x.head == :call
 
+callhead(e::Expr) = e.head
 head(e::Expr) = e.head
 children(e::Expr) = e.args
 
-operation(e::Expr) = e.args[1]
-arguments(e::Expr) = e.args[2:end]
+operation(e::Expr) = iscall(e) ? first(children(e)) : error("operation called on a non-function call expression")
+arguments(e::Expr) = iscall(e) ? @view(e.args[2:end]) : error("arguments called on a non-function call expression")
 
-function maketerm(::Type{Expr}, head, args, symtype, metadata)
+function maketerm(::Type{Expr}, head, args, symtype=nothing, metadata=nothing)
     Expr(head, args...)
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -2,15 +2,15 @@
   is_operation(f)
 
 Returns a single argument anonymous function predicate, that returns `true` if and only if
-the argument to the predicate satisfies `istree` and `operation(x) == f` 
+the argument to the predicate satisfies `iscall` and `operation(x) == f` 
 """
-is_operation(f) = @nospecialize(x) -> istree(x) && (operation(x) == f)
+is_operation(f) = @nospecialize(x) -> iscall(x) && (operation(x) == f)
 export is_operation
 
 
 """
   node_count(t)
-Count the nodes in a symbolic expression tree satisfying `istree` and `arguments`.
+Count the nodes in a symbolic expression tree satisfying `isexpr` and `arguments`.
 """
-node_count(t) = istree(t) ? reduce(+, node_count(x) for x in arguments(t), init = 0) + 1 : 1
+node_count(t) = isexpr(t) ? reduce(+, node_count(x) for x in children(t); init=0) + 1 : 1
 export node_count

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,7 +8,6 @@ using Test
     @test operation(ex) == :f
     @test arguments(ex) == [:a, :b]
     @test iscall(ex)
-    @test ex == similarterm(ex, :f, [:a, :b])
     @test ex == maketerm(Expr, :call, [:f, :a, :b])
 
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,15 +3,12 @@ using Test
 
 @testset "Expr" begin
     ex = :(f(a, b))
-    @test operation(ex) == :f
-    @test arguments(ex) == [:a, :b]
-    @test exprhead(ex) == :call
-    @test ex == similarterm(ex, :f, [:a, :b])
+    @test operation(ex) == :call
+    @test arguments(ex) == [:f, :a, :b]
+    @test ex == similarterm(ex, :call, [:f, :a, :b])
 
     ex = :(arr[i, j])
-    @test operation(ex) == getindex
+    @test operation(ex) == :ref
     @test arguments(ex) == [:arr, :i, :j]
-    @test exprhead(ex) == :ref
-    @test ex == similarterm(ex, :ref, [:arr, :i, :j]; exprhead = :ref)
     @test ex == similarterm(ex, :ref, [:arr, :i, :j])
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,12 +3,19 @@ using Test
 
 @testset "Expr" begin
     ex = :(f(a, b))
-    @test operation(ex) == :call
-    @test arguments(ex) == [:f, :a, :b]
-    @test ex == similarterm(ex, :call, [:f, :a, :b])
+    @test head(ex) == :call
+    @test children(ex) == [:f, :a, :b]
+    @test operation(ex) == :f
+    @test arguments(ex) == [:a, :b]
+    @test iscall(ex)
+    @test ex == similarterm(ex, :f, [:a, :b])
+    @test ex == maketerm(Expr, :call, [:f, :a, :b])
+
 
     ex = :(arr[i, j])
-    @test operation(ex) == :ref
-    @test arguments(ex) == [:arr, :i, :j]
-    @test ex == similarterm(ex, :ref, [:arr, :i, :j])
+    @test head(ex) == :ref
+    @test_throws ErrorException operation(ex)
+    @test_throws ErrorException arguments(ex)
+    @test !iscall(ex)
+    @test ex == maketerm(Expr, :ref, [:arr, :i, :j])
 end


### PR DESCRIPTION
As discussed in our meeting, this PR simply removes exprhead. Because the documentation of `similarterm(x, head, args)` currently says `x` is allowed to be a type, I believe that correct implementations of similarterm already need to follow exactly the same semantics that we proposed for `maketerm` in our discussion. Thus, I have just made that clearer by specifying that implementers must overload `similarterm(T::DataType, head, args)` and providing a simple ``similarterm(x, head, args) = similarterm(T::DataType, head, args)` definition. I don't think the rename to maketerm is necessary.

@shashi @0x0f0f0f 